### PR TITLE
qubes-issue #5036 qrexec-wrapper IO deadlock causes qopen-in-vm (and remote) to wait indefinitely

### DIFF
--- a/src/qrexec-wrapper/qrexec-wrapper.c
+++ b/src/qrexec-wrapper/qrexec-wrapper.c
@@ -619,7 +619,6 @@ static DWORD handle_child_output(
         LogVerbose("reading...");
         ok = ReadFile(pipe->ReadEndpoint, buffer, MAX_DATA_CHUNK,
                       &nread, NULL); // this can block
-        // nread is set to zero on entry
         //
         // EOF is signaled by either:
         // - ok and nread == 0
@@ -630,8 +629,9 @@ static DWORD handle_child_output(
         // has been closed.
         if (!ok && GetLastError() != ERROR_BROKEN_PIPE)
         {
+            // if !ok, then nread == 0
+            // Signal error condition by sending EOF
             perror("ReadFile");
-            goto cleanup;
         }
         eof = nread == 0;
         // EOF is signaled to the remote via zero count


### PR DESCRIPTION
A fix for qubes issue #5306, a deadlock that causes qopen-in-vm (and probably others) to wait indefinitely. One key observation is if the sending virtual machine shuts down, the document is opened in the receiving VM.

This fix addresses two key issues:
1. EOF is signaled on an anonymous pipe by error ERROR_BROKEN_PIPE,
2. EOF must be signaled to the remote by sending a zero-length message.

After replacing the qrexec-wrapper, "Edit in VM" and derivatives work as expected.