### PR TITLE
Add App.config to service-policy to support .NET framework 4.0+

### DIFF
--- a/core-agent-windows.wxs
+++ b/core-agent-windows.wxs
@@ -133,6 +133,7 @@ DisplayName='Installation directory'
                     </Component>
                     <Component Id='ServicePolicy' Guid='{F9818E4E-76C4-40DE-A8F3-945336C954B1}'>
                         <File Id='service_policy.exe' Source='bin\AnyCPU\service-policy.exe' KeyPath='yes' />
+                        <File Id='service_policy.exe.config' Source='bin\AnyCPU\service-policy.exe.config'/>
                         <File Id='service_policy.cfg' Source='src\service-policy\service-policy.cfg' />
                     </Component>
                     <Component Id='AdvertiseTools' Guid='{DEDA44D9-6A58-4DE7-902A-643FB594B93C}'>

--- a/vs2017/service-policy/App.config
+++ b/vs2017/service-policy/App.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v2.0.50727" />
+    <supportedRuntime version="v4.0" />
+  </startup>
+</configuration>

--- a/vs2017/service-policy/service-policy.csproj
+++ b/vs2017/service-policy/service-policy.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\src\service-policy\service-policy.cfg" />
+    <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Uses App.config to set the preferred runtime version to 2.0/3.0/3.5 (v2.0.50727), but enable it to run on 4.0+ (this doesn't happen automatically for targets prior to 4.0). This way it should run on both Win7 and Win 8/8.1/10 right out of the box.

QubesOS/qubes-issues/issues/5091

References:
https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10
https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/startup/supportedruntime-element