### PR TITLE
Add Windows qvm-connect-tcp support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ LDFLAGS += -Wl,--as-needed -lqubesdb-client -lwindows-utils -lshlwapi -lwtsapi32
 
 #TODO: drop ask-vm-and-run.exe
 TOOLS = $(addprefix $(OUTDIR)/, advertise-tools.exe ask-vm-and-run.exe network-setup.exe prepare-volume.exe qrexec-agent.exe qrexec-client-vm.exe qrexec-wrapper.exe qrexec-stdio-forwarder.exe)
-QREXEC_SERVICES = $(addprefix $(OUTDIR)/, clipboard-copy.exe clipboard-paste.exe file-receiver.exe file-sender.exe get-image-rgba.exe open-in-vm.exe open-url.exe set-gui-mode.exe vm-file-editor.exe wait-for-logon.exe window-icon-updater.exe)
-RPC_FILES = $(addprefix $(OUTDIR_ANY)/qubes-rpc/,qubes.ClipboardCopy qubes.ClipboardPaste qubes.Filecopy qubes.GetAppMenus qubes.GetImageRGBA qubes.OpenInVM qubes.OpenURL qubes.SetDateTime qubes.SetGuiMode qubes.StartApp qubes.VMShell qubes.WaitForSession qubes.SuspendPostAll)
+QREXEC_SERVICES = $(addprefix $(OUTDIR)/, clipboard-copy.exe clipboard-paste.exe file-receiver.exe file-sender.exe get-image-rgba.exe open-in-vm.exe open-url.exe set-gui-mode.exe vm-file-editor.exe wait-for-logon.exe window-icon-updater.exe connect-tcp.exe)
+RPC_FILES = $(addprefix $(OUTDIR_ANY)/qubes-rpc/,qubes.ClipboardCopy qubes.ClipboardPaste qubes.Filecopy qubes.GetAppMenus qubes.GetImageRGBA qubes.OpenInVM qubes.OpenURL qubes.SetDateTime qubes.SetGuiMode qubes.StartApp qubes.VMShell qubes.WaitForSession qubes.SuspendPostAll qubes.ConnectTCP)
 RPC_SCRIPTS = $(addprefix $(OUTDIR_ANY)/, get-appmenus.ps1 set-time.ps1 start-app.ps1 update-time.bat qvm-connect-tcp.bat)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 OUTDIR = bin/$(ARCH)
 OUTDIR_ANY = bin/AnyCPU
 CFLAGS += -Iinclude -DUNICODE -D_UNICODE -mwindows -D_WIN32_WINNT=0x0600 -std=c11 -fgnu89-inline
-LDFLAGS += -Wl,--as-needed -lqubesdb-client -lwindows-utils -lshlwapi -lwtsapi32 -lwsock32 -liphlpapi -lsetupapi -lole32 -lcomctl32 -lrpcrt4 -luuid -lntdll -Wl,--no-insert-timestamp
+LDFLAGS += -Wl,--as-needed -lqubesdb-client -lwindows-utils -lshlwapi -lwtsapi32 -lwsock32 -liphlpapi -lsetupapi -lole32 -lcomctl32 -lrpcrt4 -luuid -lntdll -lws2_32 -Wl,--no-insert-timestamp
 
 #TODO: drop ask-vm-and-run.exe
-TOOLS = $(addprefix $(OUTDIR)/, advertise-tools.exe ask-vm-and-run.exe network-setup.exe prepare-volume.exe qrexec-agent.exe qrexec-client-vm.exe qrexec-wrapper.exe)
+TOOLS = $(addprefix $(OUTDIR)/, advertise-tools.exe ask-vm-and-run.exe network-setup.exe prepare-volume.exe qrexec-agent.exe qrexec-client-vm.exe qrexec-wrapper.exe qrexec-stdio-forwarder.exe)
 QREXEC_SERVICES = $(addprefix $(OUTDIR)/, clipboard-copy.exe clipboard-paste.exe file-receiver.exe file-sender.exe get-image-rgba.exe open-in-vm.exe open-url.exe set-gui-mode.exe vm-file-editor.exe wait-for-logon.exe window-icon-updater.exe)
 RPC_FILES = $(addprefix $(OUTDIR_ANY)/qubes-rpc/,qubes.ClipboardCopy qubes.ClipboardPaste qubes.Filecopy qubes.GetAppMenus qubes.GetImageRGBA qubes.OpenInVM qubes.OpenURL qubes.SetDateTime qubes.SetGuiMode qubes.StartApp qubes.VMShell qubes.WaitForSession qubes.SuspendPostAll)
-RPC_SCRIPTS = $(addprefix $(OUTDIR_ANY)/, get-appmenus.ps1 set-time.ps1 start-app.ps1 update-time.bat)
+RPC_SCRIPTS = $(addprefix $(OUTDIR_ANY)/, get-appmenus.ps1 set-time.ps1 start-app.ps1 update-time.bat qvm-connect-tcp.bat)
 
 
 all: $(OUTDIR) $(OUTDIR_ANY) $(OUTDIR_ANY)/qubes-rpc $(TOOLS) $(QREXEC_SERVICES) $(RPC_FILES) $(RPC_SCRIPTS) $(OUTDIR_ANY)/service-policy.exe $(OUTDIR_ANY)/service-policy.cfg $(OUTDIR)/relocate-dir.exe

--- a/src/qrexec-client-vm/qrexec-client-vm.c
+++ b/src/qrexec-client-vm/qrexec-client-vm.c
@@ -24,8 +24,13 @@
 // trigger_service_params (service params), size_t (local handler path size), local handler path (WCHARs).
 // Local handler will be launched as the local endpoint for the triggered service.
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <ws2ipdef.h>
+#include <ws2def.h>
 #include <windows.h>
 #include <strsafe.h>
+#include <process.h>
 
 #include <qrexec.h>
 #include <log.h>
@@ -34,53 +39,203 @@
 #include <pipe-server.h>
 #include <exec.h>
 
-int __cdecl wmain(int argc, WCHAR *argv[])
+#define MAX_SIZE_FORWARDER_COMMANDLINE 256
+#define MAX_SIZE_PIPE_NAME 256
+#define MAX_SIZE_BUFFER 65536
+
+typedef struct _CONNECTION_DATA
 {
-    HANDLE readPipe, writePipe;
-    BOOL success = FALSE;
-    PWSTR pipeName = L"\\\\.\\pipe\\qrexec_trigger";
-    struct trigger_service_params triggerParams = { 0 };
-    ULONG status;
+    ULONG id;
+    SOCKET clientSocket;
+    HANDLE writePipe;
+    HANDLE readPipe;
+} CONNECTION_DATA, *PCONNECTION_DATA;
+
+PWSTR g_DomainName, g_ServiceName, g_CommandLine;
+struct trigger_service_params g_TriggerParams = { 0 };
+
+ULONG CreatePipes(ULONG id, WCHAR* pipeServerName, WCHAR* pipeClientName, HANDLE* writePipe, HANDLE* readPipe)
+{
+    ULONG status = ERROR_SUCCESS;
+    StringCchPrintf(pipeServerName, MAX_SIZE_PIPE_NAME, L"\\\\.\\pipe\\stdio_forward_%d-%d", _getpid(), id);
+    StringCchPrintf(pipeClientName, MAX_SIZE_PIPE_NAME, L"\\\\.\\pipe\\stdio_forward_%d-%d_client", _getpid(), id);
+
+    LogDebug("Creating pipes to forward stdio");
+
+    PSECURITY_DESCRIPTOR sd;
+    PACL acl;
+    SECURITY_ATTRIBUTES sa = { 0 };
+
+    status = CreatePublicPipeSecurityDescriptor(&sd, &acl);
+    if (status != ERROR_SUCCESS)
+        return win_perror2(status, "create pipe security descriptor");
+
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = FALSE;
+    sa.lpSecurityDescriptor = sd;
+
+    *writePipe = CreateNamedPipe(pipeServerName,
+                                 PIPE_ACCESS_OUTBOUND,
+                                 PIPE_TYPE_BYTE | PIPE_WAIT,
+                                 PIPE_UNLIMITED_INSTANCES,
+                                 MAX_SIZE_BUFFER,
+                                 MAX_SIZE_BUFFER,
+                                 0,
+                                 &sa);
+
+    *readPipe = CreateNamedPipe(pipeClientName,
+                                PIPE_ACCESS_INBOUND,
+                                PIPE_TYPE_BYTE | PIPE_WAIT,
+                                PIPE_UNLIMITED_INSTANCES,
+                                MAX_SIZE_BUFFER,
+                                MAX_SIZE_BUFFER,
+                                0,
+                                &sa);
+
+    return ERROR_SUCCESS;
+}
+
+ULONG ConnectPipes(WCHAR* pipeServerName, WCHAR* pipeClientName, HANDLE writePipe, HANDLE readPipe)
+{
+    DWORD cbPipeName;
+    DWORD written;
+
+    // wait for connection
+    while (!ConnectNamedPipe(writePipe, NULL) && GetLastError() != ERROR_PIPE_CONNECTED)
+    {
+        LogVerbose("waiting for outbound connection, pipe %s", pipeServerName);
+        Sleep(10);
+    }
+
+    LogVerbose("outbound pipe connected");
+
+    // send the name to the client
+    cbPipeName = (DWORD) (wcslen(pipeClientName) + 1) * sizeof(WCHAR);
+    if (!WriteFile(writePipe, &cbPipeName, sizeof(cbPipeName), &written, NULL))
+        return win_perror("writing size of inbound pipe name");
+
+    if (!WriteFile(writePipe, pipeClientName, cbPipeName, &written, NULL))
+        return win_perror("writing name of inbound pipe");
+
+    while (!ConnectNamedPipe(readPipe, NULL) && GetLastError() != ERROR_PIPE_CONNECTED)
+    {
+        LogVerbose("waiting for inbound connection, pipe %s", pipeClientName);
+        Sleep(10);
+    }
+
+    LogVerbose("inbound pipe connected");
+
+    return ERROR_SUCCESS;
+}
+
+DWORD WINAPI ReadPipeWriteStdoutThread(HANDLE readPipe)
+{
+    HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    BYTE buffer[MAX_SIZE_BUFFER];
+    DWORD bytesRead;
+
+    while (ReadFile(readPipe, &buffer, MAX_SIZE_BUFFER, &bytesRead, NULL))
+        if (!bytesRead || !QioWriteBuffer(stdoutHandle, &buffer, bytesRead))
+            break;
+
+    // received an eof on the reading pipe, closing the pipe
+    CloseHandle(readPipe);
+    // the remote has closed the connection, close stdout to propogate the eof
+    CloseHandle(stdoutHandle);
+
+    return ERROR_SUCCESS;
+}
+
+void ReadStdinWritePipe(HANDLE writePipe)
+{
+    HANDLE stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
+    BYTE buffer[MAX_SIZE_BUFFER];
+    DWORD bytesRead;
+
+    while (ReadFile(stdinHandle, &buffer, MAX_SIZE_BUFFER, &bytesRead, NULL))
+        if (!bytesRead || !QioWriteBuffer(writePipe, &buffer, bytesRead))
+            break;
+
+    // received an eof on stdin, close the handle
+    CloseHandle(stdinHandle);
+    // to propogate the eof from stdin via the write pipe, explicitly close the pipe
+    CloseHandle(writePipe);
+}
+
+ULONG ProcessArguments(WCHAR *argv[], BOOL *stdioMode, ULONG *tcpListenPort)
+{
+    PWSTR qubesListener = L"qubes.tcp-listen+";
     UCHAR *argumentUtf8;
     HRESULT hresult;
-    size_t size;
-    PWSTR domainName, serviceName, commandLine;
+    ULONG status = ERROR_BAD_ARGUMENTS;
 
-    domainName = GetArgument();
-    serviceName = GetArgument();
-    commandLine = GetArgument();
+    g_DomainName = GetArgument();
+    g_ServiceName = GetArgument();
+    g_CommandLine = GetArgument();
 
-    if (!domainName || !serviceName || !commandLine)
+    if (!g_DomainName || !g_ServiceName)
     {
-        LogError("Usage: %s domain name|qrexec service name|local program [local program arguments]\n", argv[0]);
+        LogError("Usage: %s domain name|qrexec service name[|local program [local program arguments]]\n", argv[0]);
         return ERROR_INVALID_PARAMETER;
     }
 
-    LogDebug("domain '%s', service '%s', local command '%s'", domainName, serviceName, commandLine);
+    LogDebug("domain '%s', service '%s'", g_DomainName, g_ServiceName);
+    if (!g_CommandLine || wcsncmp(g_CommandLine, qubesListener, wcslen(qubesListener)) == 0)
+    {
+        if (g_CommandLine)
+        {
+            LogDebug("tcp listen local command '%s'", g_CommandLine);
+
+            long port = wcstol(g_CommandLine + wcslen(qubesListener), NULL, 10);
+            if (port < 1 || port > 65535)
+            {
+                LogError("Invalid port (%d) number provided for TCP listen mode.", port);
+                return win_perror2(ERROR_BAD_ARGUMENTS, "wcstol");
+            }
+
+            *tcpListenPort = port;
+        }
+        else
+        {
+            LogDebug("no local command, defaulting to piping stdin/stdout");
+            *stdioMode = TRUE;
+        }
+    }
+    else
+        LogDebug("local command '%s'", g_CommandLine);
 
     // Prepare the parameter structure containing the first two arguments.
     argumentUtf8 = NULL;
-    status = ConvertUTF16ToUTF8(serviceName, &argumentUtf8, NULL);
+    status = ConvertUTF16ToUTF8(g_ServiceName, &argumentUtf8, NULL);
     if (ERROR_SUCCESS != status)
         return win_perror2(status, "ConvertUTF16ToUTF8");
 
-    hresult = StringCchCopyA(triggerParams.service_name, sizeof(triggerParams.service_name), argumentUtf8);
+    hresult = StringCchCopyA(g_TriggerParams.service_name, sizeof(g_TriggerParams.service_name), argumentUtf8);
     if (FAILED(hresult))
         return win_perror2(hresult, "StringCchCopyA");
 
     ConvertFree(argumentUtf8);
     argumentUtf8 = NULL;
 
-    status = ConvertUTF16ToUTF8(domainName, &argumentUtf8, NULL);
+    status = ConvertUTF16ToUTF8(g_DomainName, &argumentUtf8, NULL);
     if (ERROR_SUCCESS != status)
         return win_perror2(status, "ConvertUTF16ToUTF8");
 
-    hresult = StringCchCopyA(triggerParams.target_domain, sizeof(triggerParams.target_domain), argumentUtf8);
+    hresult = StringCchCopyA(g_TriggerParams.target_domain, sizeof(g_TriggerParams.target_domain), argumentUtf8);
     if (FAILED(hresult))
         return win_perror2(hresult, "StringCchCopyA");
 
     ConvertFree(argumentUtf8);
     argumentUtf8 = NULL;
+
+    return ERROR_SUCCESS;
+}
+
+ULONG RequestQrexec(PWSTR commandLine)
+{
+    HANDLE readPipe, writePipe;
+    size_t size;
+    PWSTR pipeName = L"\\\\.\\pipe\\qrexec_trigger";
 
     LogDebug("Connecting to qrexec-agent");
 
@@ -90,17 +245,364 @@ int __cdecl wmain(int argc, WCHAR *argv[])
     CloseHandle(readPipe);
     LogDebug("Sending the parameters to qrexec-agent");
 
-    if (!QioWriteBuffer(writePipe, &triggerParams, sizeof(triggerParams)))
+    if (!QioWriteBuffer(writePipe, &g_TriggerParams, sizeof(g_TriggerParams)))
+    {
+        CloseHandle(writePipe);
         return win_perror("write trigger params to agent");
+    }
 
     size = (wcslen(commandLine) + 1) * sizeof(WCHAR);
     if (!QioWriteBuffer(writePipe, &size, sizeof(size)))
+    {
+        CloseHandle(writePipe);
         return win_perror("write command size to agent");
+    }
 
     if (!QioWriteBuffer(writePipe, commandLine, (DWORD)size))
+    {
+        CloseHandle(writePipe);
         return win_perror("write command to agent");
+    }
 
     CloseHandle(writePipe);
+
+    return ERROR_SUCCESS;
+}
+
+ULONG SetupPipes(ULONG id, HANDLE* writePipe, HANDLE* readPipe)
+{
+    ULONG status;
+    WCHAR pipeServerName[MAX_SIZE_PIPE_NAME];
+    WCHAR pipeClientName[MAX_SIZE_PIPE_NAME];
+    WCHAR commandLine[MAX_SIZE_FORWARDER_COMMANDLINE];
+
+    // create pipes to forward tcp stream to qrexec-wrapper
+    status = CreatePipes(id, pipeServerName, pipeClientName, writePipe, readPipe);
+    if (ERROR_SUCCESS != status)
+        return win_perror2(status, "creating pipe server");
+
+    StringCchPrintf(commandLine, MAX_SIZE_FORWARDER_COMMANDLINE, L"qrexec-stdio-forwarder.exe %d-%d", _getpid(), id);
+    status = RequestQrexec(commandLine);
+    if (ERROR_SUCCESS != status)
+    {
+        CloseHandle(*writePipe);
+        CloseHandle(*readPipe);
+        return win_perror2(status, "requesting command execution");
+    }
+
+    status = ConnectPipes(pipeServerName, pipeClientName, *writePipe, *readPipe);
+    if (ERROR_SUCCESS != status)
+    {
+        CloseHandle(*writePipe);
+        CloseHandle(*readPipe);
+        return win_perror2(status, "connecting pipes");
+    }
+
+    return ERROR_SUCCESS;
+}
+
+ULONG RunStdioMode()
+{
+    ULONG status;
+    HANDLE writePipe, readPipe;
+
+    status = SetupPipes(0, &writePipe, &readPipe);
+    if (status != ERROR_SUCCESS)
+        return win_perror2(status, "setting up pipes");
+
+    // the reading pipe/thread will be closed when the remote closes it's side of the connection
+    HANDLE readPipeThread = CreateThread(NULL, 0, ReadPipeWriteStdoutThread, readPipe, 0, NULL);
+    if (!readPipeThread)
+    {
+        CloseHandle(writePipe);
+        CloseHandle(readPipe);
+        return win_perror("creating read pipe thread");
+    }
+
+    // this is blocking till an eof is received on stdin
+    ReadStdinWritePipe(writePipe);
+
+    // block till eof is received on the read pipe (remote closed connection)
+    WaitForSingleObject(readPipeThread, INFINITE);
+    CloseHandle(readPipeThread);
+
+    return ERROR_SUCCESS;
+}
+
+DWORD WINAPI ReadPipeWriteSocketThread(PVOID param)
+{
+    PCONNECTION_DATA connectionData = param;
+
+    BYTE buffer[MAX_SIZE_BUFFER];
+    DWORD bytesRead;
+    int bytesSend;
+
+    while (ReadFile(connectionData->readPipe, &buffer, MAX_SIZE_BUFFER, &bytesRead, NULL))
+    {
+        if (!bytesRead)
+            break;
+
+        bytesSend = send(connectionData->clientSocket, buffer, bytesRead, 0);
+        if (bytesSend == SOCKET_ERROR)
+        {
+            LogDebug("socket send resulted in error: %d", WSAGetLastError());
+            break;
+        }
+
+        if (bytesSend != bytesRead)
+        {
+            LogError("socket send less than expected: %d - %d", bytesRead, bytesSend);
+            break;
+        }
+    }
+
+    // received an eof on the reading pipe (or encountered an error), closing the pipe
+    CloseHandle(connectionData->readPipe);
+    // the remote has closed the connection, disable socket sending to propogate FIN
+    if (shutdown(connectionData->clientSocket, SD_SEND) != ERROR_SUCCESS)
+        return win_perror2(WSAGetLastError(), "close socket send");
+
+    return ERROR_SUCCESS;
+}
+
+ULONG ReadSocketWritePipe(PCONNECTION_DATA connectionData)
+{
+    ULONG status;
+    BYTE buffer[MAX_SIZE_BUFFER];
+    int bytesRead;
+
+    while (TRUE)
+    {
+        bytesRead = recv(connectionData->clientSocket, buffer, MAX_SIZE_BUFFER, 0);
+        if (bytesRead == SOCKET_ERROR)
+        {
+            LogDebug("socket recv resulted in error: %d", WSAGetLastError());
+            break;
+        }
+
+        if (!bytesRead || !QioWriteBuffer(connectionData->writePipe, &buffer, bytesRead))
+            break;
+    }
+
+    // received an FIN on socket (or encountered an error when reading from the socket), close socket receiving
+    status = shutdown(connectionData->clientSocket, SD_RECEIVE);
+    // to propogate the eof from stdin via the write pipe, explicitly close the pipe
+    CloseHandle(connectionData->writePipe);
+
+    if (status != ERROR_SUCCESS)
+        return win_perror2(WSAGetLastError(), "close socket receive");
+
+    return ERROR_SUCCESS;
+}
+
+// this method is responsible for freeing the connectionData memory
+DWORD WINAPI HandleConnection(PVOID param)
+{
+    ULONG status;
+    PCONNECTION_DATA connectionData = param;
+
+    status = SetupPipes(connectionData->id, &connectionData->writePipe, &connectionData->readPipe);
+    if (status != ERROR_SUCCESS)
+    {
+        // even if shutdown fails, we still need to close the socket
+        shutdown(connectionData->clientSocket, SD_BOTH);
+
+        if (closesocket(connectionData->clientSocket) != ERROR_SUCCESS)
+        {
+            // free connectionData
+            free(connectionData);
+
+            return win_perror2(WSAGetLastError(), "closing socket");
+        }
+
+        // free connectionData
+        free(connectionData);
+
+        return win_perror2(status, "setting up pipes");
+    }
+
+    // the reading pipe/thread will be closed when the remote closes it's side of the connection
+    // before the thread closes down it will close the send side of the socket
+    HANDLE readPipeThread = CreateThread(NULL, 0, ReadPipeWriteSocketThread, param, 0, NULL);
+    if (!readPipeThread)
+    {
+        status = GetLastError();
+        // even if shutdown fails, we still need to close the socket
+        shutdown(connectionData->clientSocket, SD_BOTH);
+
+        CloseHandle(connectionData->writePipe);
+        CloseHandle(connectionData->readPipe);
+
+        if (closesocket(connectionData->clientSocket) != ERROR_SUCCESS)
+        {
+            // free connectionData
+            free(connectionData);
+
+            return win_perror2(WSAGetLastError(), "closing socket");
+        }
+
+        // free connectionData
+        free(connectionData);
+
+        return win_perror2(status, "creating read pipe thread");
+    }
+
+    // this is blocking till an eof is received on the socket
+    // ignore returned status, wait for full socket shutdown before closing the socket
+    ReadSocketWritePipe(connectionData);
+
+    // block till eof is received on the read pipe (remote closed connection)
+    WaitForSingleObject(readPipeThread, INFINITE);
+    CloseHandle(readPipeThread);
+
+    // socket send and receive have been closed already, close socket
+    closesocket(connectionData->clientSocket);
+
+    // free connectionData
+    free(connectionData);
+
+    return ERROR_SUCCESS;
+}
+
+ULONG RunTcpListenMode(ULONG tcpListenPort)
+{
+    ULONG status;
+    WSADATA wsaData;
+    SOCKET listenSocket = INVALID_SOCKET;
+    struct addrinfo* addrInfo = NULL;
+    struct addrinfo hints;
+    CHAR portStr[10];
+    ULONG connectionId = 1;
+
+    // get a string representation of the port
+    snprintf(portStr, 10, "%u", tcpListenPort);
+
+    // init winsock2
+    status = WSAStartup(MAKEWORD(2,2), &wsaData);
+    if (status != ERROR_SUCCESS)
+        return win_perror2(status, "WSAStartup");
+
+    ZeroMemory(&hints, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    hints.ai_flags = AI_PASSIVE;
+
+    // convert hostname:port to address, only listen for connections on localhost
+    status = getaddrinfo("localhost", portStr, &hints, &addrInfo);
+    if (status != ERROR_SUCCESS)
+    {
+        WSACleanup();
+        return win_perror2(status, "getaddrinfo");
+    }
+
+    // create listen socket on the specified address
+    listenSocket = socket(addrInfo->ai_family, addrInfo->ai_socktype, addrInfo->ai_protocol);
+    if (listenSocket == INVALID_SOCKET)
+    {
+        status = WSAGetLastError();
+        freeaddrinfo(addrInfo);
+        WSACleanup();
+        return win_perror2(status, "create socket");
+    }
+
+    // bind socket to network address
+    status = bind(listenSocket, addrInfo->ai_addr, (int)addrInfo->ai_addrlen);
+    if (status != ERROR_SUCCESS)
+    {
+        status = WSAGetLastError();
+        closesocket(listenSocket);
+        freeaddrinfo(addrInfo);
+        WSACleanup();
+        return win_perror2(status, "binding socket");
+    }
+
+    freeaddrinfo(addrInfo);
+
+    // start listeing on the socket
+    status = listen(listenSocket, SOMAXCONN);
+    if (status != ERROR_SUCCESS)
+    {
+        status = WSAGetLastError();
+        closesocket(listenSocket);
+        WSACleanup();
+        return win_perror2(status, "listening on socket");
+    }
+
+    // loop indefinitely to accept new connections
+    while (TRUE)
+    {
+        SOCKET clientSocket = accept(listenSocket, NULL, NULL);
+        if (clientSocket == INVALID_SOCKET)
+        {
+            status = WSAGetLastError();
+            closesocket(listenSocket);
+            WSACleanup();
+            return win_perror2(status, "accept socket");
+        }
+
+        PCONNECTION_DATA connectionData = malloc(sizeof(CONNECTION_DATA));
+        if (!connectionData)
+        {
+            closesocket(clientSocket);
+            closesocket(listenSocket);
+            WSACleanup();
+            return win_perror2(ERROR_NOT_ENOUGH_MEMORY, "allocating memory connection data");
+        }
+
+        connectionData->clientSocket = clientSocket;
+        connectionData->id = connectionId;
+
+        connectionId++;
+
+        HANDLE connectionThread = CreateThread(NULL, 0, HandleConnection, connectionData, 0, NULL);
+        if (!connectionThread)
+        {
+            closesocket(clientSocket);
+            closesocket(listenSocket);
+            WSACleanup();
+            return win_perror("creating tcp connection handle thread");
+        }
+
+        // close the handle, the threads finish on their own
+        CloseHandle(connectionThread);
+    }
+
+    // never should come here, but just in case cleanup
+    closesocket(listenSocket);
+    WSACleanup();
+
+    return ERROR_SUCCESS;
+}
+
+int __cdecl wmain(int argc, WCHAR *argv[])
+{
+    BOOL stdioMode = FALSE;
+    ULONG tcpListenPort = 0;
+    ULONG status;
+
+    status = ProcessArguments(argv, &stdioMode, &tcpListenPort);
+    if (status != ERROR_SUCCESS)
+        return win_perror2(status, "ProcessArguments");
+
+    if (stdioMode)
+    {
+        status = RunStdioMode();
+        if (status != ERROR_SUCCESS)
+            return win_perror2(status, "running qrexec-client-vm in stdio mode");
+    }
+    else if (tcpListenPort)
+    {
+        status = RunTcpListenMode(tcpListenPort);
+        if (status != ERROR_SUCCESS)
+            return win_perror2(status, "running qrexec-client-vm in tcp listen mode");
+    }
+    else
+    {
+        status = RequestQrexec(g_CommandLine);
+        if (ERROR_SUCCESS != status)
+            return win_perror2(status, "requesting local command execution");
+    }
 
     LogVerbose("exiting");
 

--- a/src/qrexec-services/connect-tcp/connect-tcp.c
+++ b/src/qrexec-services/connect-tcp/connect-tcp.c
@@ -1,0 +1,197 @@
+/*
+ * The Qubes OS Project, http://www.qubes-os.org
+ *
+ * Copyright (c) Invisible Things Lab
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <ws2ipdef.h>
+#include <ws2def.h>
+#include <windows.h>
+#include <qubes-io.h>
+#include <log.h>
+#include <exec.h>
+
+#define MAX_SIZE_BUFFER 65536
+
+SOCKET g_ClientSocket = INVALID_SOCKET;
+
+DWORD WINAPI ReadStdinWriteSocketThread(PVOID param)
+{
+    HANDLE stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
+    BYTE buffer[MAX_SIZE_BUFFER];
+    DWORD bytesRead;
+    int bytesSend;
+
+    while (ReadFile(stdinHandle, &buffer, MAX_SIZE_BUFFER, &bytesRead, NULL))
+    {
+        if (!bytesRead)
+            break;
+
+        bytesSend = send(g_ClientSocket, buffer, bytesRead, 0);
+        if (bytesSend == SOCKET_ERROR)
+        {
+            LogDebug("socket send resulted in error: %d", WSAGetLastError());
+            break;
+        }
+
+        if (bytesSend != bytesRead)
+        {
+            LogError("socket send less than expected: %d - %d", bytesRead, bytesSend);
+            break;
+        }
+    }
+
+    // received an eof on the reading pipe (or encountered an error), closing stdin
+    CloseHandle(stdinHandle);
+    // the remote has closed the connection, disable socket sending to propogate FIN
+    if (shutdown(g_ClientSocket, SD_SEND) != ERROR_SUCCESS)
+        return win_perror2(WSAGetLastError(), "close socket send");
+
+    return ERROR_SUCCESS;
+}
+
+ULONG ReadSocketWriteStdout()
+{
+    HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    ULONG status;
+    BYTE buffer[MAX_SIZE_BUFFER];
+    int bytesRead;
+
+    while (TRUE)
+    {
+        bytesRead = recv(g_ClientSocket, buffer, MAX_SIZE_BUFFER, 0);
+        if (bytesRead == SOCKET_ERROR)
+        {
+            LogDebug("socket recv resulted in error: %d", WSAGetLastError());
+            break;
+        }
+
+        if (!bytesRead || !QioWriteBuffer(stdoutHandle, &buffer, bytesRead))
+            break;
+    }
+
+    // received an FIN on socket (or encountered an error when reading from the socket), close socket receiving
+    status = shutdown(g_ClientSocket, SD_RECEIVE);
+    // to propogate the eof from the socket to the remote, explicitly close stdout
+    CloseHandle(stdoutHandle);
+
+    if (status != ERROR_SUCCESS)
+        return win_perror2(WSAGetLastError(), "close socket receive");
+
+    return ERROR_SUCCESS;
+}
+
+int APIENTRY wWinMain(HINSTANCE instance, HINSTANCE previousInstance, WCHAR *commandLine, int showState)
+{
+    ULONG status;
+    PWSTR portStr;
+    CHAR finalPortStr[10];
+    long port;
+
+    // winsock data
+    WSADATA wsaData;
+    struct addrinfo* addrInfo = NULL;
+    struct addrinfo hints;
+    
+    portStr = GetArgument();
+    port = wcstol(portStr, NULL, 10);
+
+    if (port < 1 || port > 65535)
+    {
+        LogError("Invalid port (%d) number provided to connect to.", port);
+        return win_perror2(ERROR_BAD_ARGUMENTS, "wcstol");
+    }
+
+    // for added safety using the port number converted to a string instead of the original argument
+    snprintf(finalPortStr, 10, "%u", port);
+
+    // init winsock2
+    status = WSAStartup(MAKEWORD(2,2), &wsaData);
+    if (status != ERROR_SUCCESS)
+        return win_perror2(status, "WSAStartup");
+
+    ZeroMemory(&hints, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+
+    // convert hostname:port to address, only connect to localhost
+    status = getaddrinfo("localhost", finalPortStr, &hints, &addrInfo);
+    if (status != ERROR_SUCCESS)
+    {
+        WSACleanup();
+        return win_perror2(status, "getaddrinfo");
+    }
+
+    // create client socket
+    g_ClientSocket = socket(addrInfo->ai_family, addrInfo->ai_socktype, addrInfo->ai_protocol);
+    if (g_ClientSocket == INVALID_SOCKET)
+    {
+        status = WSAGetLastError();
+        freeaddrinfo(addrInfo);
+        WSACleanup();
+        return win_perror2(status, "create socket");
+    }
+
+    // connect client socket to tcp server
+    if (connect(g_ClientSocket, addrInfo->ai_addr, (int)addrInfo->ai_addrlen) == SOCKET_ERROR)
+    {
+        status = WSAGetLastError();
+        closesocket(g_ClientSocket);
+        freeaddrinfo(addrInfo);
+        WSACleanup();
+        return win_perror2(status, "connect socket");
+    }
+
+    // free as no longer needed
+    freeaddrinfo(addrInfo);
+
+    HANDLE readStdinThread = CreateThread(NULL, 0, ReadStdinWriteSocketThread, NULL, 0, NULL);
+    if (!readStdinThread)
+    {
+        status = GetLastError();
+        // even if shutdown fails, we still need to close the socket
+        shutdown(g_ClientSocket, SD_BOTH);
+
+        // explicitly close stdio handles to propogate eof to the caller of this service
+        // not really necessary as the handles will be closed on the imminent closure of the service
+        CloseHandle(GetStdHandle(STD_INPUT_HANDLE));
+        CloseHandle(GetStdHandle(STD_OUTPUT_HANDLE));
+
+        if (closesocket(g_ClientSocket) != ERROR_SUCCESS)
+            return win_perror2(WSAGetLastError(), "closing socket");
+
+        return win_perror2(status, "creating read pipe thread");
+    }
+
+    // this is blocking till an eof is received on the socket
+    // ignore returned status, wait for full socket shutdown before closing the socket
+    ReadSocketWriteStdout();
+
+    // block till eof is received on the stdin (remote closed connection)
+    WaitForSingleObject(readStdinThread, INFINITE);
+    CloseHandle(readStdinThread);
+
+    // socket send and receive have been closed already, close socket
+    closesocket(g_ClientSocket);
+    WSACleanup();
+
+    return ERROR_SUCCESS;
+}

--- a/src/qrexec-services/connect-tcp/version.rc
+++ b/src/qrexec-services/connect-tcp/version.rc
@@ -1,0 +1,3 @@
+#define QTW_FILEDESCRIPTION_STR "Qubes connect tcp service"
+
+#include "..\..\version_common.rc"

--- a/src/qrexec-services/qubes.ConnectTCP
+++ b/src/qrexec-services/qubes.ConnectTCP
@@ -1,0 +1,1 @@
+connect-tcp.exe %1

--- a/src/qrexec-services/qvm-connect-tcp.bat
+++ b/src/qrexec-services/qvm-connect-tcp.bat
@@ -1,0 +1,48 @@
+@echo off
+if defined DEBUG @echo on
+
+setlocal enabledelayedexpansion
+
+set LOCALPORT=
+set DOMAIN=
+set FINALPORT=
+
+set INPUT=%1
+set REPLACED=!INPUT::=temp:!
+
+for /f "tokens=1 delims=:" %%i in ("!REPLACED!") do set LOCALPORT=%%i
+for /f "tokens=2 delims=:" %%i in ("!REPLACED!") do set DOMAIN=%%i
+for /f "tokens=3 delims=:" %%i in ("!REPLACED!") do set FINALPORT=%%i
+
+if not defined LOCALPORT goto help
+if not defined DOMAIN goto help
+if not defined FINALPORT goto help
+
+if "%LOCALPORT:~0,-4%" == "" (set FINALLOCALPORT=%FINALPORT%) else (set FINALLOCALPORT=%LOCALPORT:~0,-4%)
+if "%DOMAIN:~0,-4%" == "" (set FINALDOMAIN=@default) else (set FINALDOMAIN=%DOMAIN:~0,-4%)
+
+if 1%FINALLOCALPORT% NEQ +1%FINALLOCALPORT% goto port
+if 1%FINALPORT% NEQ +1%FINALPORT% goto port
+
+if %FINALLOCALPORT% LSS 1 goto port
+if %FINALPORT% LSS 1 goto port
+
+if %FINALLOCALPORT% GTR 65535 goto port
+if %FINALPORT% GTR 65535 goto port
+
+echo Binding TCP '%FINALDOMAIN%:%FINALPORT%' to 'localhost:%FINALLOCALPORT%'...
+
+pushd %~dp0..\bin\
+START qrexec-client-vm.exe %FINALDOMAIN%^|qubes.ConnectTCP+%FINALPORT%^|qubes.tcp-listen+%FINALLOCALPORT%
+popd
+
+exit /b
+
+:help
+echo "Usage: qvm-connect-tcp [localport]:[vmname]:[port]"
+echo "Bind localport to another VM port using the qubes.ConnectTCP RPC service."
+exit /b
+
+:port
+echo "Invalid port provided"
+exit /b

--- a/src/qrexec-stdio-forwarder/qrexec-stdio-forwarder.c
+++ b/src/qrexec-stdio-forwarder/qrexec-stdio-forwarder.c
@@ -1,0 +1,112 @@
+/*
+ * The Qubes OS Project, http://www.qubes-os.org
+ *
+ * Copyright (c) Invisible Things Lab
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+// This program is used to forward stdin from qrexec-client-vm to the stdin from qrexec-wrapper
+// and forward the stdout from qrexec-wrapper to the stdout from qrexec-client-vm
+// Both programs communicate via a pipe created by qrexec-client-vm
+
+#include <windows.h>
+#include <strsafe.h>
+
+#include <qrexec.h>
+#include <log.h>
+#include <qubes-io.h>
+#include <pipe-server.h>
+#include <exec.h>
+
+#define MAX_SIZE_NAME_FORWARDING_PIPE_SERVER 256
+#define MAX_SIZE_BUFFER 65536
+
+DWORD WINAPI ReadPipeWriteStdoutThread(HANDLE readPipe)
+{
+    HANDLE stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    BYTE buffer[MAX_SIZE_BUFFER];
+    DWORD bytesRead;
+
+    while (ReadFile(readPipe, &buffer, MAX_SIZE_BUFFER, &bytesRead, NULL))
+        if (!bytesRead || !QioWriteBuffer(stdoutHandle, &buffer, bytesRead))
+            break;
+
+    // close read pipe, it reached eof
+    CloseHandle(readPipe);
+    // explicitly close stdout to propogate the eof
+    CloseHandle(stdoutHandle);
+}
+
+void ReadStdinWritePipe(HANDLE writePipe)
+{
+    HANDLE stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
+    BYTE buffer[MAX_SIZE_BUFFER];
+    DWORD bytesRead;
+
+    while (ReadFile(stdinHandle, &buffer, MAX_SIZE_BUFFER, &bytesRead, NULL))
+        if (!bytesRead || !QioWriteBuffer(writePipe, &buffer, bytesRead))
+            break;
+
+    // close stdin, received an eof
+    CloseHandle(stdinHandle);
+    // close write pipe to propogate the eof
+    CloseHandle(writePipe);
+}
+
+int __cdecl wmain(int argc, WCHAR *argv[])
+{
+    PWSTR targetPidAndId;
+    HANDLE readPipe, writePipe;
+
+    targetPidAndId = GetArgument();
+
+    if (!targetPidAndId)
+    {
+        LogError("Usage: %s target pid-id\n", argv[0]);
+        return ERROR_BAD_ARGUMENTS;
+    }
+
+    LogDebug("target pid-id '%s'", targetPidAndId);
+    WCHAR pipeName[MAX_SIZE_NAME_FORWARDING_PIPE_SERVER];
+    StringCchPrintf(pipeName, MAX_SIZE_NAME_FORWARDING_PIPE_SERVER, L"\\\\.\\pipe\\stdio_forward_%s", targetPidAndId);
+
+    LogDebug("Connecting to qrexec-client-vm");
+
+    if (ERROR_SUCCESS != QpsConnect(pipeName, &readPipe, &writePipe))
+        return win_perror("connect to qrexec-client-vm");
+
+    // start processing data coming in from the read pipe (local) in its own thread
+    HANDLE readPipeThread = CreateThread(NULL, 0, ReadPipeWriteStdoutThread, readPipe, 0, NULL);
+    if (!readPipeThread)
+    {
+        CloseHandle(writePipe);
+        CloseHandle(readPipe);
+        return win_perror("creating read pipe thread");
+    }
+
+    // start processing data coming in from stdin (remote) in the main thread
+    // block till eof is received on stdin (remote closed connection)
+    ReadStdinWritePipe(writePipe);
+
+    // block till eof is received on the read pipe (local closed connection)
+    WaitForSingleObject(readPipeThread, INFINITE);
+    CloseHandle(readPipeThread);
+
+    LogVerbose("exiting");
+
+    return ERROR_SUCCESS;
+}

--- a/src/qrexec-stdio-forwarder/version.rc
+++ b/src/qrexec-stdio-forwarder/version.rc
@@ -1,0 +1,3 @@
+#define QTW_FILEDESCRIPTION_STR "Qubes RPC STDIO forwarder"
+
+#include "..\version_common.rc"


### PR DESCRIPTION
## Summary:
- The purpose of this pull request is to add [qvm-connect-tcp](https://www.qubes-os.org/doc/firewall/#opening-a-single-tcp-port-to-other-network-isolated-qube) support for Windows VMs.
- Currently this implementation only covers outgoing connections. Depending on any and all feedback I can get on what I have so far I will add the functionality as well to connect into a Windows VM.
- Using qrexec-client-vm without a local program will instead tunnel STDIO to the remote similar to the behavior on Linux.
- TCP listening is implemented directly in qrexec-client-vm to avoid the need for a socat like tool on Windows.
- A batch script is provided with exactly the same behavior as its Linux counterpart.

## TCP/Socat/Ncat:
On Linux socat is used for TCP <-> STDIO conversion, running socat on Windows requires a POSIX like environment, e.g., Cygwin.
To avoid the need for such an environment a tool native to Windows that could replace socat could be used. The only reasonable option for such a tool would be ncat. However, the ncat option has the following problems:
- The license.
- Their precompiled static binary is outdated and contains a critical functional bug that they [resolved](https://github.com/nmap/nmap/commit/c3d079a5844b0df19f200099ac6561050db12cc2) in 2013. Their precompiled binary is from 2010 and still has the bug.
- Antivirus software (notably Windows Defender) qualifies it as a hacker tool and quarantines it.
- Mingw builds of just ncat are "supported" but seems like an afterthought.

Instead of these options, I added about 200 lines of code to `qrexec-client-vm` to directly support tcp listening.

## Open Questions:
- Where should the qvm-connect-tcp.bat script go, and how will it be made accessible to the user (unless it already exists, I would propose a new directory in` Qubes Tools` that can be added to the PATH).
- Is this custom TCP listening solution acceptable? If not, what would be the preferred alternative?
- If it is acceptable, shall I write a small tool to allow incoming connections and add it to `qrexec-services`? Or do we prefer to use ncat (or a similar program) for that?
- In the batch script we are jumping through quite some hoops to achieve similar behavior to the Linux version. Would it be preferable to change the semantics on Windows for the sake of simplifying the script? Or is the current solution, maybe with some tweaks from someone more experienced in batch script writing, acceptable?

## ToDo:
- [x] Add support for incoming TCP connections (now only outgoing is supported).
- [ ] Add Visual Studio build support (now only mingw builds work).
- [ ] Update the iso installer builder to include the new files.
- [ ] Add the qvm-connect-tcp.bat directory to the PATH for easy access.