### PR TITLE
(partial) fix for fc37 based dom0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ QREXEC_SERVICES = $(addprefix $(OUTDIR)/, clipboard-copy.exe clipboard-paste.exe
 RPC_FILES = $(addprefix $(OUTDIR_ANY)/qubes-rpc/,qubes.ClipboardCopy qubes.ClipboardPaste qubes.Filecopy qubes.GetAppMenus qubes.GetImageRGBA qubes.OpenInVM qubes.OpenURL qubes.SetDateTime qubes.SetGuiMode qubes.StartApp qubes.VMShell qubes.WaitForSession qubes.SuspendPostAll)
 RPC_SCRIPTS = $(addprefix $(OUTDIR_ANY)/, get-appmenus.ps1 set-time.ps1 start-app.ps1 update-time.bat)
 
+RELOCATE_DIR_LDFLAGS := $(if $(wildcard /usr/*-w64-mingw32/sys-root/mingw/lib/libntdllcrt.a),-lntdllcrt)
+
 
 all: $(OUTDIR) $(OUTDIR_ANY) $(OUTDIR_ANY)/qubes-rpc $(TOOLS) $(QREXEC_SERVICES) $(RPC_FILES) $(RPC_SCRIPTS) $(OUTDIR_ANY)/service-policy.exe $(OUTDIR_ANY)/service-policy.cfg $(OUTDIR)/relocate-dir.exe
 
@@ -39,7 +41,7 @@ $(OUTDIR_ANY)/service-policy.cfg: src/service-policy/service-policy.cfg
 	cp $^ $@
 
 $(OUTDIR)/relocate-dir.exe: $(wildcard src/relocate-dir/*.c) src/relocate-dir/chkstk.S
-	$(CC) $^ $(CFLAGS) -I$(DDK_PATH) -e NtProcessStartup -Wl,--subsystem,native -L $(OUTDIR) -lntdll -nostdlib -D__INTRINSIC_DEFINED__InterlockedAdd64 -municode -Wl,--no-insert-timestamp -o $@
+	$(CC) $^ $(CFLAGS) -I$(DDK_PATH) -e NtProcessStartup -Wl,--subsystem,native -L $(OUTDIR) -lntdll $(RELOCATE_DIR_LDFLAGS) -nostdlib -D__INTRINSIC_DEFINED__InterlockedAdd64 -municode -Wl,--no-insert-timestamp -o $@
 
 $(RPC_FILES): $(OUTDIR_ANY)/qubes-rpc/%: src/qrexec-services/%
 	cp $^ $@

--- a/include/customddkinc.h
+++ b/include/customddkinc.h
@@ -4,9 +4,12 @@
 
 #define __field_bcount_part(size,init) SAL__notnull SAL__byte_writableTo(size) SAL__byte_readableTo(init)
 
+#if __MINGW64_VERSION_MAJOR < 8
 DEFINE_DEVPROPKEY(DEVPKEY_Device_HardwareIds,            0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 3);     // DEVPROP_TYPE_STRING_LIST
 DEFINE_DEVPROPKEY(DEVPKEY_Device_Class,                  0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 9);     // DEVPROP_TYPE_STRING
 DEFINE_DEVPROPKEY(DEVPKEY_Device_LocationInfo,           0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0, 15);    // DEVPROP_TYPE_STRING
+#endif
+
 #define IOCTL_DISK_SET_DISK_ATTRIBUTES      CTL_CODE(IOCTL_DISK_BASE, 0x003d, METHOD_BUFFERED,     FILE_READ_ACCESS | FILE_WRITE_ACCESS)
 
 #define DISK_ATTRIBUTE_OFFLINE              0x0000000000000001


### PR DESCRIPTION
Avoid redefining DEVPKEY_*

Mingw since 8.0.0 provide them in devpkey.h.

QubesOS/qubes-issues#8048